### PR TITLE
Add es5 build in published files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.log
 .DS_Store
-dist
+es5
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js:
+  - "0.10"
+  - "0.12"
   - "4"
   - "5"
   - "6"

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,12 @@
+/* eslint-disable vars-on-top, global-require */
+
 var assert = require('chai').assert;
 
-var TestServer = require('.');
+if (typeof Promise === 'undefined') {
+  global.Promise = require('native-promise-only');
+}
+
+var TestServer = require('./index');
 
 // very simple http handler
 var app = (req, res) => {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "description": "Test node.js HTTP servers using the fetch API",
   "main": "index.js",
   "scripts": {
+    "build": "rm -r es5 > /dev/null; babel ./*.js -d es5",
+    "prepublish": "npm run build",
     "lint": "eslint *.js",
-    "mocha": "mocha *.test.js",
+    "mocha": "mocha *.test.js es5/*.test.js",
     "test": "npm run lint && npm run mocha"
   },
   "repository": {
@@ -33,10 +35,26 @@
     "node-fetch": "^1.5.1"
   },
   "devDependencies": {
+    "babel-cli": "^6.7.7",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.7.7",
+    "babel-plugin-transform-es2015-template-literals": "^6.6.5",
+    "babel-plugin-transform-object-assign": "^6.5.0",
     "chai": "3.5.0",
     "eslint": "2.8.0",
     "eslint-config-airbnb-base": "1.0.4",
     "eslint-plugin-import": "1.6.0",
-    "mocha": "2.4.5"
+    "mocha": "2.4.5",
+    "native-promise-only": "^0.8.1"
+  },
+  "files": [
+    "es5",
+    "*.js"
+  ],
+  "babel": {
+    "plugins": [
+      "transform-es2015-arrow-functions",
+      "transform-es2015-template-literals",
+      "transform-object-assign"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "rm -r es5 > /dev/null; babel ./*.js -d es5",
     "prepublish": "npm run build",
     "lint": "eslint *.js",
-    "mocha": "mocha *.test.js es5/*.test.js",
-    "test": "npm run lint && npm run mocha"
+    "mocha": "[ `echo $npm_config_node_version | cut -d. -f1` -eq 0 ] && mocha es5/*.test.js || mocha *.test.js",
+    "test": "npm run lint && npm run build && npm run mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For dumb reasons, I'm stuck on node < 4. This doesn't replace the code with an es5-built version, but instead adds an `es5` directory, so that it's opt-in via `var TestServer = require('fetch-test-server/es5')`.

This is a small enough project that I hope that you don't find the duplicated files burdensome.
