### PR TITLE
Set Fetch on TestServer to allow setting a promise implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,4 +60,6 @@ TestServer.prototype.fetch = function fetch(path, opts) {
   });
 };
 
+TestServer.Fetch = nodeFetch;
+
 module.exports = TestServer;


### PR DESCRIPTION
When actually using the results of my es5 copy, I ran into the following error:

```
Error: native promise missing, set Fetch.Promise to your favorite alternative
```

This change makes "Fetch" accessible, so that the promise implementation can be manually set.
